### PR TITLE
Fix #1596: getBoundKeys still returning table

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7009,9 +7009,7 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
 
             if (pBind)
-            {
                 pKeyBinds->Remove(pBind);
-            }
 
             bSuccess = true;
         }
@@ -7022,9 +7020,7 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
 
             if (pBind)
-            {
                 pKeyBinds->Remove(pBind);
-            }
 
             bSuccess = true;
         }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6982,9 +6982,12 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
 
     CKeyBindsInterface* pKeyBinds = g_pCore->GetKeyBinds();
     bool                bKey = pKeyBinds->IsKey(szKey);
+    CCommandBind*       pBind;
+
     if (bKey)
     {
         bool bCheckHitState = false, bHitState = true;
+
         if (szHitState)
         {
             if (stricmp(szHitState, "down") == 0)
@@ -6996,10 +6999,20 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
                 bCheckHitState = true, bHitState = false;
             }
         }
+
+
+        pBind = g_pCore->GetKeyBinds()->GetBindFromCommand(szCommandName, NULL, false, szKey, bCheckHitState, bHitState);
+
         if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
             pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
             pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
+
+            if (pBind)
+            {
+                pKeyBinds->Remove(pBind);
+            }
+
             bSuccess = true;
         }
         bHitState = false;
@@ -7007,6 +7020,12 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
             pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
+
+            if (pBind)
+            {
+                pKeyBinds->Remove(pBind);
+            }
+
             bSuccess = true;
         }
     }


### PR DESCRIPTION
Fixed getBoundKeys still returning a table when an unbound command is passed to it.
