### PR TITLE
Fix #2774

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3463,6 +3463,7 @@ bool CStaticFunctionDefinitions::RedirectPlayer(CElement* pElement, const char* 
             BitStream.pBitStream->Write(ucPasswordLength);
             BitStream.pBitStream->Write(szPassword, ucPasswordLength);
         }
+        pPlayer->SetLeavingServer(true);
         pPlayer->Send(CLuaPacket(FORCE_RECONNECT, *BitStream.pBitStream));
 
         usPort = usPort ? usPort : g_pGame->GetConfig()->GetServerPort();


### PR DESCRIPTION
Prevents the function "kickPlayer" from kicking a player being redirected to another function.

Before you go ahead and create a pull request, please make sure:

* [ ] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [ ] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

If your work is incomplete, **do not prefix your pull request with "WIP"**, instead
create a _draft_ pull request: https://github.blog/2019-02-14-introducing-draft-pull-requests/

Thank you!
